### PR TITLE
x86_64-xen-pv: Fix compilation problem

### DIFF
--- a/x86_64-xen-pv.json
+++ b/x86_64-xen-pv.json
@@ -7,7 +7,6 @@
   "env": "",
   "executables": true,
   "features": "-mmx,-sse,+soft-float",
-  "has-elf-tls": false,
   "has-rpath": false,
   "is-builtin": false,
   "linker": "rust-lld",


### PR DESCRIPTION
A single patch to address an x86 compilation warning caused by an unused field in the .json file.