### PR TITLE
xen-store: support XenStore access through /dev/xen/xenbus

### DIFF
--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 20.37,
+  "coverage_score": 28.58,
   "exclude_path": "oxerun",
   "crate_features": ""
 }

--- a/coverage_config_x86_64.json
+++ b/coverage_config_x86_64.json
@@ -1,5 +1,5 @@
 {
-  "coverage_score": 18.62,
+  "coverage_score": 20.37,
   "exclude_path": "oxerun",
   "crate_features": ""
 }

--- a/xen-store/Cargo.toml
+++ b/xen-store/Cargo.toml
@@ -11,5 +11,4 @@ edition = "2018"
 [dependencies]
 libc = ">=0.2.95"
 vmm-sys-util = ">=0.9.0"
-nix = "0.24.1"
 xen-bindings = { path = "../xen-bindings" }

--- a/xen-store/src/types.rs
+++ b/xen-store/src/types.rs
@@ -11,6 +11,7 @@
 use std::io;
 
 pub const XENSTORED_SOCKET: &str = "/var/run/xenstored/socket";
+pub const XENBUS_DEVICE: &str = "/dev/xen/xenbus";
 pub const XENSTORE_PAYLOAD_MAX: u32 = 4096;
 
 #[repr(C)]

--- a/xen-store/src/types.rs
+++ b/xen-store/src/types.rs
@@ -10,8 +10,6 @@
 
 use std::io;
 
-use nix::libc::{iovec, E2BIG};
-
 pub const XENSTORED_SOCKET: &str = "/var/run/xenstored/socket";
 pub const XENSTORE_PAYLOAD_MAX: u32 = 4096;
 
@@ -26,20 +24,17 @@ pub(crate) struct XenSocketMessage {
 }
 
 impl XenSocketMessage {
-    #[allow(clippy::ptr_arg)]
-    pub(crate) fn new(r#type: u32, iovec_buffers: &mut Vec<iovec>) -> Result<Self, std::io::Error> {
+    pub(crate) fn new(r#type: u32, payload_len: usize) -> Result<Self, std::io::Error> {
+        if payload_len > XENSTORE_PAYLOAD_MAX as usize {
+            return Err(io::Error::from_raw_os_error(libc::E2BIG));
+        }
+
         let msg = XenSocketMessage {
             r#type,
             req_id: 0,
             tx_id: 0,
-            len: iovec_buffers
-                .iter()
-                .fold(0, |acc, iovec| acc + iovec.iov_len as u32),
+            len: payload_len as u32,
         };
-
-        if msg.len > XENSTORE_PAYLOAD_MAX {
-            return Err(io::Error::from_raw_os_error(E2BIG));
-        }
 
         Ok(msg)
     }

--- a/xen-store/src/xs.rs
+++ b/xen-store/src/xs.rs
@@ -13,10 +13,12 @@
 use std::{
     collections::VecDeque,
     ffi::CString,
+    fs::{File, OpenOptions},
     io::{Error, ErrorKind, Read, Write},
     mem,
     net::Shutdown,
-    os::unix::{io::AsRawFd, net::UnixStream},
+    os::unix::{fs::OpenOptionsExt, io::AsRawFd, net::UnixStream},
+    path::Path,
     sync::{Arc, Condvar, Mutex},
     thread,
     thread::JoinHandle,
@@ -54,12 +56,37 @@ fn write_request<W: Write>(
 
 enum XenStoreTransport {
     Socket(UnixStream),
+    Device { file: File, stop_eventfd: EventFd },
+}
+
+fn default_transport(
+    socket_path: &Path,
+    device_path: &Path,
+) -> Result<XenStoreTransport, std::io::Error> {
+    UnixStream::connect(socket_path)
+        .map(XenStoreTransport::Socket)
+        .or_else(|_| {
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .custom_flags(libc::O_NONBLOCK)
+                .open(device_path)?;
+
+            Ok(XenStoreTransport::Device {
+                file,
+                stop_eventfd: EventFd::new(0)?,
+            })
+        })
 }
 
 impl XenStoreTransport {
     fn try_clone(&self) -> Result<Self, std::io::Error> {
         match self {
             Self::Socket(stream) => stream.try_clone().map(Self::Socket),
+            Self::Device { file, stop_eventfd } => Ok(Self::Device {
+                file: file.try_clone()?,
+                stop_eventfd: stop_eventfd.try_clone()?,
+            }),
         }
     }
 
@@ -73,6 +100,10 @@ impl XenStoreTransport {
                  */
                 let _ = stream.shutdown(Shutdown::Both);
             }
+            Self::Device { stop_eventfd, .. } => {
+                // Socket shutdown cannot wake this reader; use an eventfd.
+                let _ = stop_eventfd.write(1);
+            }
         }
     }
 }
@@ -81,6 +112,26 @@ impl Read for XenStoreTransport {
     fn read(&mut self, buffer: &mut [u8]) -> Result<usize, std::io::Error> {
         match self {
             Self::Socket(stream) => stream.read(buffer),
+            Self::Device { file, stop_eventfd } => {
+                if buffer.is_empty() {
+                    // Do not poll for a zero-length read.
+                    return Ok(0);
+                }
+
+                // Poll for input or shutdown; repoll after transient read errors.
+                loop {
+                    if !wait_for_device_input(file, stop_eventfd)? {
+                        return Ok(0);
+                    }
+
+                    match file.read(buffer) {
+                        Err(error)
+                            if error.kind() == ErrorKind::Interrupted
+                                || error.kind() == ErrorKind::WouldBlock => {}
+                        result => return result,
+                    }
+                }
+            }
         }
     }
 }
@@ -89,12 +140,14 @@ impl Write for XenStoreTransport {
     fn write(&mut self, buffer: &[u8]) -> Result<usize, std::io::Error> {
         match self {
             Self::Socket(stream) => stream.write(buffer),
+            Self::Device { file, .. } => file.write(buffer),
         }
     }
 
     fn flush(&mut self) -> Result<(), std::io::Error> {
         match self {
             Self::Socket(stream) => stream.flush(),
+            Self::Device { file, .. } => file.flush(),
         }
     }
 }
@@ -120,6 +173,39 @@ fn queue_message(
 
     queue.push_back(message);
     cvar.notify_one();
+}
+
+fn wait_for_device_input(file: &File, stop_eventfd: &EventFd) -> Result<bool, std::io::Error> {
+    let poll_fd = |fd| libc::pollfd {
+        fd,
+        events: libc::POLLIN,
+        revents: 0,
+    };
+    let mut poll_fds = [poll_fd(file.as_raw_fd()), poll_fd(stop_eventfd.as_raw_fd())];
+
+    loop {
+        // SAFETY: poll_fds is valid for both entries during the call.
+        if unsafe { libc::poll(poll_fds.as_mut_ptr(), poll_fds.len() as _, -1) } < 0 {
+            match Error::last_os_error() {
+                error if error.kind() == ErrorKind::Interrupted => continue,
+                error => return Err(error),
+            }
+        }
+
+        // Give shutdown priority over pending input.
+        if poll_fds[1].revents & libc::POLLIN != 0 {
+            return Ok(false);
+        }
+
+        let revents = poll_fds[0].revents;
+        if revents & libc::POLLNVAL != 0 {
+            return Err(Error::from_raw_os_error(libc::EBADF));
+        }
+
+        if revents & (libc::POLLIN | libc::POLLERR | libc::POLLHUP) != 0 {
+            return Ok(true);
+        }
+    }
 }
 
 fn thread_function(
@@ -225,9 +311,9 @@ pub struct XenStoreHandle {
 }
 
 impl XenStoreHandle {
-    /// Connect to XenStore through a Unix domain socket.
+    /// Connect to XenStore through a Unix domain socket or `/dev/xen/xenbus`.
     pub fn new() -> Result<Self, std::io::Error> {
-        let transport = XenStoreTransport::Socket(UnixStream::connect(XENSTORED_SOCKET)?);
+        let transport = default_transport(Path::new(XENSTORED_SOCKET), Path::new(XENBUS_DEVICE))?;
         Self::from_transport(transport)
     }
 
@@ -374,9 +460,22 @@ impl Drop for XenStoreHandle {
 
 #[cfg(test)]
 mod tests {
-    use std::sync::mpsc;
+    use std::{os::fd::OwnedFd, sync::mpsc, time::Duration};
+
+    use vmm_sys_util::tempdir::TempDir;
 
     use super::*;
+
+    fn device_transport_from_stream(
+        stream: UnixStream,
+    ) -> Result<XenStoreTransport, std::io::Error> {
+        stream.set_nonblocking(true)?;
+
+        Ok(XenStoreTransport::Device {
+            file: File::from(OwnedFd::from(stream)),
+            stop_eventfd: EventFd::new(0)?,
+        })
+    }
 
     #[derive(Default)]
     struct ShortWriter {
@@ -454,6 +553,82 @@ mod tests {
         drop(handle);
         release_sender.send(()).unwrap();
         server_thread.join().unwrap()?;
+        Ok(())
+    }
+
+    #[test]
+    fn dropping_idle_device_handle_stops_reader() -> Result<(), std::io::Error> {
+        // Keep the peer open so shutdown alone stops the reader.
+        let (client, _server) = UnixStream::pair()?;
+        let handle = XenStoreHandle::from_transport(device_transport_from_stream(client)?)?;
+        drop(handle);
+        Ok(())
+    }
+
+    #[test]
+    fn device_read_stops_after_partial_data() -> Result<(), std::io::Error> {
+        let (client, mut server) = UnixStream::pair()?;
+        let transport = device_transport_from_stream(client)?;
+        let mut rx_transport = transport.try_clone()?;
+        let (read_sender, read_receiver) = mpsc::channel();
+        let (result_sender, result_receiver) = mpsc::channel();
+
+        let reader = thread::spawn(move || {
+            let mut buffer = [0; 4];
+            let read = rx_transport.read(&mut buffer).unwrap();
+            read_sender.send(read).unwrap();
+            let result = rx_transport.read_exact(&mut buffer[read..]);
+            result_sender.send((result, buffer)).unwrap();
+        });
+
+        server.write_all(b"ab")?;
+        assert_eq!(
+            read_receiver
+                .recv_timeout(Duration::from_secs(1))
+                .map_err(|error| Error::new(ErrorKind::TimedOut, error))?,
+            2
+        );
+        transport.shutdown();
+
+        let (result, buffer) = result_receiver
+            .recv_timeout(Duration::from_secs(1))
+            .map_err(|error| Error::new(ErrorKind::TimedOut, error))?;
+        assert_eq!(result.unwrap_err().kind(), ErrorKind::UnexpectedEof);
+        assert_eq!(&buffer[..2], b"ab");
+        reader.join().unwrap();
+        Ok(())
+    }
+
+    #[test]
+    fn device_read_honors_shutdown_with_ready_input() -> Result<(), std::io::Error> {
+        let (client, mut server) = UnixStream::pair()?;
+        let transport = device_transport_from_stream(client)?;
+        let mut rx_transport = transport.try_clone()?;
+
+        server.write_all(b"abcd")?;
+        transport.shutdown();
+
+        let mut buffer = [0; 4];
+        assert_eq!(
+            rx_transport.read_exact(&mut buffer).unwrap_err().kind(),
+            ErrorKind::UnexpectedEof
+        );
+        Ok(())
+    }
+
+    #[test]
+    fn default_transport_falls_back_to_device() -> Result<(), std::io::Error> {
+        let temp_dir = TempDir::new()?;
+        let socket_path = temp_dir.as_path().join("missing-socket");
+        let device_path = temp_dir.as_path().join("xenbus");
+        let _device = std::fs::OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create_new(true)
+            .open(&device_path)?;
+
+        let transport = default_transport(&socket_path, &device_path)?;
+        assert!(matches!(transport, XenStoreTransport::Device { .. }));
         Ok(())
     }
 }

--- a/xen-store/src/xs.rs
+++ b/xen-store/src/xs.rs
@@ -22,7 +22,6 @@ use std::{
     thread::JoinHandle,
 };
 
-use nix::libc::iovec;
 use vmm_sys_util::eventfd::{EventFd, EFD_SEMAPHORE};
 use xen_bindings::bindings::xs_watch_type;
 
@@ -33,6 +32,25 @@ pub const XS_READ: u32 = 2;
 pub const XS_WATCH: u32 = 4;
 pub const XS_WRITE: u32 = 11;
 pub const XS_WATCH_EVENT: u32 = 15;
+
+fn message_bytes(message: &XenSocketMessage) -> &[u8] {
+    // SAFETY: XenSocketMessage is #[repr(C)] with four u32 fields and no padding.
+    unsafe {
+        std::slice::from_raw_parts(
+            std::ptr::addr_of!(*message).cast(),
+            mem::size_of::<XenSocketMessage>(),
+        )
+    }
+}
+
+fn write_request<W: Write>(
+    writer: &mut W,
+    message: &XenSocketMessage,
+    payload: &[u8],
+) -> Result<(), std::io::Error> {
+    writer.write_all(message_bytes(message))?;
+    writer.write_all(payload)
+}
 
 fn queue_message(
     condvar: &Arc<(
@@ -188,44 +206,14 @@ impl XenStoreHandle {
         })
     }
 
-    fn xs_transaction(
-        &self,
-        r#type: u32,
-        iovec_buffers: &mut Vec<iovec>,
-    ) -> Result<String, std::io::Error> {
-        let mut xen_socket_msg = XenSocketMessage::new(r#type, iovec_buffers)?;
+    fn xs_transaction(&self, r#type: u32, payload: &[u8]) -> Result<String, std::io::Error> {
+        let xen_socket_msg = XenSocketMessage::new(r#type, payload.len())?;
         let (lock, cvar) = &*self.reply_condvar;
 
         let mut tx_socket = self.tx_socket.lock().unwrap();
-        {
-            // SAFETY: `xen_socket_msg` is `XenSocketMessage` bytes sized.
-            let xen_socket_msg_slice: &[u8] = unsafe {
-                std::slice::from_raw_parts(
-                    std::ptr::addr_of_mut!(xen_socket_msg).cast(),
-                    mem::size_of::<XenSocketMessage>(),
-                )
-            };
 
-            /*
-             * Grabbing the mutex guarantees there will only be
-             * one active transcation at a time.
-             */
-            tx_socket.write_all(xen_socket_msg_slice)?;
-        }
-
-        // SAFETY: tx_socket is a valid file descriptor and the pointer/length we pass
-        // are valid allocated values.
-        let ret = unsafe {
-            libc::writev(
-                tx_socket.as_raw_fd(),
-                iovec_buffers.as_ptr(),
-                iovec_buffers.len() as i32,
-            )
-        };
-
-        if ret < 0 {
-            return Err(Error::last_os_error());
-        }
+        // Serialize complete request/response transactions.
+        write_request(&mut *tx_socket, &xen_socket_msg, payload)?;
 
         let mut reply_vec = lock.lock().unwrap();
         while reply_vec.is_empty() {
@@ -247,49 +235,23 @@ impl XenStoreHandle {
     }
 
     pub fn read_str(&self, path: &str) -> Result<String, std::io::Error> {
-        let c_path = CString::new(path)?;
-        let mut iovec_buffers = vec![iovec {
-            iov_base: c_path.as_ptr() as *mut _,
-            iov_len: path.len() + 1,
-        }];
+        let payload = CString::new(path)?.into_bytes_with_nul();
 
-        self.xs_transaction(XS_READ, &mut iovec_buffers)
+        self.xs_transaction(XS_READ, &payload)
     }
 
     pub fn write_str(&self, path: &str, val: &str) -> Result<(), std::io::Error> {
-        let cpath = CString::new(path)?;
-        let cval = CString::new(val)?;
-        let mut iovec_buffers = vec![
-            iovec {
-                iov_base: cpath.as_ptr() as *mut _,
-                iov_len: path.len() + 1,
-            },
-            iovec {
-                iov_base: cval.as_ptr() as *mut _,
-                iov_len: val.len(),
-            },
-        ];
+        let mut payload = CString::new(path)?.into_bytes_with_nul();
+        payload.extend(CString::new(val)?.into_bytes());
 
-        self.xs_transaction(XS_WRITE, &mut iovec_buffers)
-            .map(|_| ())
+        self.xs_transaction(XS_WRITE, &payload).map(|_| ())
     }
 
     pub fn create_watch(&self, path: &str, token: &str) -> Result<(), std::io::Error> {
-        let cpath = CString::new(path)?;
-        let ctoken = CString::new(token)?;
-        let mut iovec_buffers = vec![
-            iovec {
-                iov_base: cpath.as_ptr() as *mut _,
-                iov_len: path.len() + 1,
-            },
-            iovec {
-                iov_base: ctoken.as_ptr() as *mut _,
-                iov_len: token.len() + 1,
-            },
-        ];
+        let mut payload = CString::new(path)?.into_bytes_with_nul();
+        payload.extend(CString::new(token)?.into_bytes_with_nul());
 
-        self.xs_transaction(XS_WATCH, &mut iovec_buffers)
-            .map(|_| ())
+        self.xs_transaction(XS_WATCH, &payload).map(|_| ())
     }
 
     pub fn read_watch(&self, index: xs_watch_type) -> Result<String, std::io::Error> {
@@ -329,13 +291,9 @@ impl XenStoreHandle {
     }
 
     pub fn directory(&self, path: &str) -> Result<Vec<i32>, std::io::Error> {
-        let c_path = CString::new(path)?;
-        let mut iovec_buffers = vec![iovec {
-            iov_base: c_path.as_ptr() as *mut _,
-            iov_len: path.len() + 1,
-        }];
+        let payload = CString::new(path)?.into_bytes_with_nul();
 
-        match self.xs_transaction(XS_DIRECTORY, &mut iovec_buffers) {
+        match self.xs_transaction(XS_DIRECTORY, &payload) {
             Ok(res) => Ok(res
                 .as_str()
                 .split('\0')
@@ -365,5 +323,51 @@ impl Drop for XenStoreHandle {
 
         /* Wait for it to stop */
         let _ = self.handler.take().unwrap().join();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[derive(Default)]
+    struct ShortWriter {
+        bytes: Vec<u8>,
+        write_calls: usize,
+    }
+
+    impl Write for ShortWriter {
+        fn write(&mut self, buffer: &[u8]) -> Result<usize, std::io::Error> {
+            self.write_calls += 1;
+
+            // Write the header, interrupt the payload, then force short writes.
+            let written = match self.write_calls {
+                1 => buffer.len(),
+                2 => return Err(Error::from(ErrorKind::Interrupted)),
+                _ => buffer.len().min(3),
+            };
+
+            self.bytes.extend_from_slice(&buffer[..written]);
+            Ok(written)
+        }
+
+        fn flush(&mut self) -> Result<(), std::io::Error> {
+            Ok(())
+        }
+    }
+
+    #[test]
+    fn writes_complete_request_after_interrupted_and_short_writes() -> Result<(), std::io::Error> {
+        let payload = b"domid\0";
+        let message = XenSocketMessage::new(XS_READ, payload.len())?;
+        let mut writer = ShortWriter::default();
+
+        write_request(&mut writer, &message, payload)?;
+
+        let mut expected = message_bytes(&message).to_vec();
+        expected.extend_from_slice(payload);
+        assert_eq!(writer.bytes, expected);
+        assert!(writer.write_calls > 2);
+        Ok(())
     }
 }

--- a/xen-store/src/xs.rs
+++ b/xen-store/src/xs.rs
@@ -52,6 +52,53 @@ fn write_request<W: Write>(
     writer.write_all(payload)
 }
 
+enum XenStoreTransport {
+    Socket(UnixStream),
+}
+
+impl XenStoreTransport {
+    fn try_clone(&self) -> Result<Self, std::io::Error> {
+        match self {
+            Self::Socket(stream) => stream.try_clone().map(Self::Socket),
+        }
+    }
+
+    fn shutdown(&self) {
+        match self {
+            Self::Socket(stream) => {
+                /*
+                 * Calling shutdown() on the socket will cause the blocking
+                 * read in thread_function() to return with an error, causing
+                 * the reader thread to stop.
+                 */
+                let _ = stream.shutdown(Shutdown::Both);
+            }
+        }
+    }
+}
+
+impl Read for XenStoreTransport {
+    fn read(&mut self, buffer: &mut [u8]) -> Result<usize, std::io::Error> {
+        match self {
+            Self::Socket(stream) => stream.read(buffer),
+        }
+    }
+}
+
+impl Write for XenStoreTransport {
+    fn write(&mut self, buffer: &[u8]) -> Result<usize, std::io::Error> {
+        match self {
+            Self::Socket(stream) => stream.write(buffer),
+        }
+    }
+
+    fn flush(&mut self) -> Result<(), std::io::Error> {
+        match self {
+            Self::Socket(stream) => stream.flush(),
+        }
+    }
+}
+
 fn queue_message(
     condvar: &Arc<(
         Mutex<VecDeque<Result<XenStoreMessage, std::io::Error>>>,
@@ -76,7 +123,7 @@ fn queue_message(
 }
 
 fn thread_function(
-    mut rx_socket: UnixStream,
+    mut rx_transport: XenStoreTransport,
     tx_eventfd: EventFd,
     reply_condvar: Arc<(
         Mutex<VecDeque<Result<XenStoreMessage, std::io::Error>>>,
@@ -102,7 +149,7 @@ fn thread_function(
                 )
             };
 
-            rx_socket.read_exact(xen_socket_reply_msg_slice)?;
+            rx_transport.read_exact(xen_socket_reply_msg_slice)?;
         }
 
         if xen_socket_reply_msg.r#type == XS_READ && xen_socket_reply_msg.len == 0 {
@@ -119,7 +166,7 @@ fn thread_function(
 
         buffer.resize(xen_socket_reply_msg.len as usize, 0);
 
-        rx_socket.read_exact(buffer.as_mut_slice())?;
+        rx_transport.read_exact(buffer.as_mut_slice())?;
 
         if xen_socket_reply_msg.r#type != XS_READ
             && xen_socket_reply_msg.r#type != XS_WRITE
@@ -173,14 +220,19 @@ pub struct XenStoreHandle {
         Mutex<VecDeque<Result<XenStoreMessage, std::io::Error>>>,
         Condvar,
     )>,
-    tx_socket: Mutex<UnixStream>,
+    tx_transport: Mutex<XenStoreTransport>,
     rx_eventfd: EventFd,
 }
 
 impl XenStoreHandle {
+    /// Connect to XenStore through a Unix domain socket.
     pub fn new() -> Result<Self, std::io::Error> {
-        let tx_socket = UnixStream::connect(XENSTORED_SOCKET)?;
-        let rx_socket = tx_socket.try_clone()?;
+        let transport = XenStoreTransport::Socket(UnixStream::connect(XENSTORED_SOCKET)?);
+        Self::from_transport(transport)
+    }
+
+    fn from_transport(tx_transport: XenStoreTransport) -> Result<Self, std::io::Error> {
+        let rx_transport = tx_transport.try_clone()?;
         let tx_eventfd = EventFd::new(EFD_SEMAPHORE)?;
         let rx_eventfd = tx_eventfd.try_clone()?;
         let reply_condvar = Arc::new((Mutex::new(VecDeque::new()), Condvar::new()));
@@ -190,7 +242,7 @@ impl XenStoreHandle {
 
         let handler = thread::spawn(|| {
             thread_function(
-                rx_socket,
+                rx_transport,
                 tx_eventfd,
                 reply_condvar_cloned,
                 watch_condvar_cloned,
@@ -201,7 +253,7 @@ impl XenStoreHandle {
             handler: Some(handler),
             reply_condvar,
             watch_condvar,
-            tx_socket: Mutex::new(tx_socket),
+            tx_transport: Mutex::new(tx_transport),
             rx_eventfd,
         })
     }
@@ -210,10 +262,10 @@ impl XenStoreHandle {
         let xen_socket_msg = XenSocketMessage::new(r#type, payload.len())?;
         let (lock, cvar) = &*self.reply_condvar;
 
-        let mut tx_socket = self.tx_socket.lock().unwrap();
+        let mut tx_transport = self.tx_transport.lock().unwrap();
 
         // Serialize complete request/response transactions.
-        write_request(&mut *tx_socket, &xen_socket_msg, payload)?;
+        write_request(&mut *tx_transport, &xen_socket_msg, payload)?;
 
         let mut reply_vec = lock.lock().unwrap();
         while reply_vec.is_empty() {
@@ -311,15 +363,9 @@ impl XenStoreHandle {
 
 impl Drop for XenStoreHandle {
     fn drop(&mut self) {
-        let tx_socket = self.tx_socket.lock().unwrap();
+        let tx_transport = self.tx_transport.lock().unwrap();
 
-        /*
-         * Calling shutdown() on the socket will cause the blocking
-         * rx_socket in thread_function() to return with an error
-         * condition, something that will automatically break the
-         * loop and cause the thread to stop.
-         */
-        let _ = tx_socket.shutdown(Shutdown::Both);
+        tx_transport.shutdown();
 
         /* Wait for it to stop */
         let _ = self.handler.take().unwrap().join();
@@ -328,6 +374,8 @@ impl Drop for XenStoreHandle {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::mpsc;
+
     use super::*;
 
     #[derive(Default)]
@@ -368,6 +416,44 @@ mod tests {
         expected.extend_from_slice(payload);
         assert_eq!(writer.bytes, expected);
         assert!(writer.write_calls > 2);
+        Ok(())
+    }
+
+    #[test]
+    fn unix_transport_round_trip() -> Result<(), std::io::Error> {
+        let (client, mut server) = UnixStream::pair()?;
+        let handle = XenStoreHandle::from_transport(XenStoreTransport::Socket(client))?;
+        // Keep the peer open until the handle shuts down its reader.
+        let (release_sender, release_receiver) = mpsc::channel();
+
+        let server_thread = thread::spawn(move || -> Result<(), std::io::Error> {
+            let mut request = XenSocketMessage::default();
+            // SAFETY: request provides exclusive storage for one XenSocketMessage.
+            let request_bytes = unsafe {
+                std::slice::from_raw_parts_mut(
+                    std::ptr::addr_of_mut!(request).cast(),
+                    mem::size_of::<XenSocketMessage>(),
+                )
+            };
+            server.read_exact(request_bytes)?;
+            assert_eq!(request.r#type, XS_READ);
+
+            let mut payload = vec![0; request.len as usize];
+            server.read_exact(&mut payload)?;
+            assert_eq!(payload, b"domid\0");
+
+            let response_payload = b"7\0";
+            let response = XenSocketMessage::new(XS_READ, response_payload.len())?;
+            server.write_all(message_bytes(&response))?;
+            server.write_all(response_payload)?;
+            release_receiver.recv().unwrap();
+            Ok(())
+        });
+
+        assert_eq!(handle.read_str("domid")?, "7\0");
+        drop(handle);
+        release_sender.send(()).unwrap();
+        server_thread.join().unwrap()?;
         Ok(())
     }
 }


### PR DESCRIPTION
### Summary of the PR

XenStoreHandle::new() currently connects only through the Unix domain socket, which is normally unavailable in a driver domain. Linux exposes XenStore through /dev/xen/xenbus.

First abstract the transport I/O without changing the socket path, then add the device fallback. Open the device with O_NONBLOCK and poll it with a shutdown eventfd so partial reads remain interruptible.

### Dependency

Depends-on: #18
(This branch is stacked on #18. The last two commits are new here.)

### Requirements

- [x] All commits in this PR have Signed-Off-By trailers (with
  `git commit -s`), and the commit message has max 60 characters for the
  summary and max 75 characters for each description line.
- [x] All added/changed functionality has a corresponding unit/integration
  test.
- [ ] All added/changed public-facing functionality has entries in the "Upcoming 
  Release" section of CHANGELOG.md (if no such section exists, please create one).
- [x] Any newly added `unsafe` code is properly documented.
